### PR TITLE
Move 'all' to top, since otherwise $(VENV) is run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ UNAME         := $(shell uname)
 PATH          := $(shell echo $$PATH)
 
 
+all: check
+
+
 .SILENT: $(VENV)
 $(VENV):
 ifeq ($(shell which python3),)
@@ -27,9 +30,6 @@ endif
 
 $(PIP): $(VENV)
 $(PYTHON): $(VENV)
-
-
-all: check
 
 
 .PHONY: check


### PR DESCRIPTION
With the current configuration Make finds `$(VENV)` before `all`, meaning that a simple `make` causes the `$(VENV)` recipe to be executed.